### PR TITLE
(chore) Wires In Secrets

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,6 +17,9 @@ jobs:
       contents: "read"
     steps:
       - uses: actions/checkout@v4
+      - uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.KIPOS_SECRETS_DEPLOY_KEY }}
       - uses: DeterminateSystems/nix-installer-action@main
       - uses: DeterminateSystems/magic-nix-cache-action@main
       - uses: DeterminateSystems/flake-checker-action@main

--- a/README.md
+++ b/README.md
@@ -15,11 +15,13 @@ Collection of system configs for my machines.
     ```
 - [x] Build `test` VM locally
 - [x] Build `test` VM in GHA
-- [x] Set up renovate on repo
-- [ ] Clean up `hello.nix`
+- [x] Wire secrets into the repo (ref [blog post][secrets_blog_post])
+- [ ] Auto-update flake via GHA
 - [ ] See if disko works with tests
+- [ ] Clean up `hello.nix`
 
 [nix_vm_gist]: https://gist.github.com/FlakM/0535b8aa7efec56906c5ab5e32580adf
+[secrets]: https://unmovedcentre.com/posts/secrets-management/#overview-and-video
 
 ## Refs
 
@@ -27,3 +29,4 @@ Other people's configs...
 
 - https://github.com/dustinlyons/nixos-config/blob/main/modules/darwin/casks.nix
 - https://github.com/cameronraysmith/nix-config/blob/main/flake.nix
+- https://0xda.de/blog/2024/07/framework-and-nixos-sops-nix-secrets-management/#separating-our-secrets-from-our-config

--- a/README.md
+++ b/README.md
@@ -16,12 +16,23 @@ Collection of system configs for my machines.
 - [x] Build `test` VM locally
 - [x] Build `test` VM in GHA
 - [x] Wire secrets into the repo (ref [blog post][secrets_blog_post])
+    - [x] Set up `kipos-secrets` non-public repo to hold SOPS yaml (ref [sops-nix][sops_nix]
+        for basic getting-started info)
+    - [x] Generate `kipos-secrets` [Deploy Key][gh_deploy_keys] pair (public key
+        goes into `kipos-secrets` settings, private key goes into `kipos`
+        secret)
+    - [x] Update `kipos` GHA to load private Deploy Key from secret into
+        ssh-agent
+    - [x] Reference `kipos-secrets` as an input to flake
+    - [x] Wire dummy secrets into `hello.nix` test
 - [ ] Auto-update flake via GHA
 - [ ] See if disko works with tests
 - [ ] Clean up `hello.nix`
 
 [nix_vm_gist]: https://gist.github.com/FlakM/0535b8aa7efec56906c5ab5e32580adf
-[secrets]: https://unmovedcentre.com/posts/secrets-management/#overview-and-video
+[gh_deploy_keys]: https://docs.github.com/en/authentication/connecting-to-github-with-ssh/managing-deploy-keys#deploy-keys
+[sops_nix]: https://github.com/Mic92/sops-nix
+[secrets_blog_post]: https://unmovedcentre.com/posts/secrets-management/#overview-and-video
 
 ## Refs
 

--- a/flake.lock
+++ b/flake.lock
@@ -139,6 +139,7 @@
         "nix-darwin": "nix-darwin",
         "nixpkgs": "nixpkgs",
         "secrets": "secrets",
+        "sops-nix": "sops-nix",
         "treefmt-nix": "treefmt-nix_2"
       }
     },
@@ -164,6 +165,26 @@
         "shallow": true,
         "type": "git",
         "url": "ssh://git@github.com/johnjameswhitman/kipos-secrets.git"
+      }
+    },
+    "sops-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1737411508,
+        "narHash": "sha256-j9IdflJwRtqo9WpM0OfAZml47eBblUHGNQTe62OUqTw=",
+        "owner": "Mic92",
+        "repo": "sops-nix",
+        "rev": "015d461c16678fc02a2f405eb453abb509d4e1d4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Mic92",
+        "repo": "sops-nix",
+        "type": "github"
       }
     },
     "treefmt-nix": {

--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1719733833,
-        "narHash": "sha256-6h2EqZU9bL9rHlXE+2LCBgnDImejzbS+4dYsNDDFlkY=",
+        "lastModified": 1737038063,
+        "narHash": "sha256-rMEuiK69MDhjz1JgbaeQ9mBDXMJ2/P8vmOYRbFndXsk=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "d185770ea261fb5cf81aa5ad1791b93a7834d12c",
+        "rev": "bf0abfde48f469c256f2b0f481c6281ff04a5db2",
         "type": "github"
       },
       "original": {
@@ -63,11 +63,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1736370755,
-        "narHash": "sha256-iWcjToBpx4PUd74uqvIGAfqqVfyrvRLRauC/SxEKIF0=",
+        "lastModified": 1737504076,
+        "narHash": "sha256-/B4XJnzYU/6K1ZZOBIgsa3K4pqDJrnC2579c44c+4rI=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "57733bd1dc81900e13438e5b4439239f1b29db0e",
+        "rev": "65cc1fa8e36ceff067daf6cfb142331f02f524d3",
         "type": "github"
       },
       "original": {
@@ -78,11 +78,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1719468428,
-        "narHash": "sha256-vN5xJAZ4UGREEglh3lfbbkIj+MPEYMuqewMn4atZFaQ=",
+        "lastModified": 1737717945,
+        "narHash": "sha256-ET91TMkab3PmOZnqiJQYOtSGvSTvGeHoegAv4zcTefM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1e3deb3d8a86a870d925760db1a5adecc64d329d",
+        "rev": "ecd26a469ac56357fd333946a99086e992452b6a",
         "type": "github"
       },
       "original": {
@@ -152,10 +152,10 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1737747806,
-        "narHash": "sha256-o1WPFyyyKbk2cpB3ZeOEE4O70hJc/M1CF4ca2yrLDCI=",
+        "lastModified": 1737758107,
+        "narHash": "sha256-6ZSJV+x/aJgxF5Yo69+dGpUFQqVuUPFPDR1NxUWHzFo=",
         "ref": "main",
-        "rev": "c1801bb96ed2234fec1f1b67e4af721ee23dc9a7",
+        "rev": "b890f14a7def7bc2c0302ac0359fb15a67226fb9",
         "shallow": true,
         "type": "git",
         "url": "ssh://git@github.com/johnjameswhitman/kipos-secrets.git"
@@ -212,11 +212,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1736154270,
-        "narHash": "sha256-p2r8xhQZ3TYIEKBoiEhllKWQqWNJNoT9v64Vmg4q8Zw=",
+        "lastModified": 1737483750,
+        "narHash": "sha256-5An1wq5U8sNycOBBg3nsDDgpwBmR9liOpDGlhliA6Xo=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "13c913f5deb3a5c08bb810efd89dc8cb24dd968b",
+        "rev": "f2cc121df15418d028a59c9737d38e3a90fbaf8f",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -38,6 +38,24 @@
         "type": "github"
       }
     },
+    "flake-parts_2": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib_2"
+      },
+      "locked": {
+        "lastModified": 1736143030,
+        "narHash": "sha256-+hu54pAoLDEZT9pjHlqL9DNzWz0NbUn8NEAHP7PQPzU=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "b905f6fc23a9051a6e1b741e1438dbfc0634c6de",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
     "nix-darwin": {
       "inputs": {
         "nixpkgs": [
@@ -86,6 +104,18 @@
         "url": "https://github.com/NixOS/nixpkgs/archive/e9b51731911566bbf7e4895475a87fe06961de0b.tar.gz"
       }
     },
+    "nixpkgs-lib_2": {
+      "locked": {
+        "lastModified": 1735774519,
+        "narHash": "sha256-CewEm1o2eVAnoqb6Ml+Qi9Gg/EfNAxbRx1lANGVyoLI=",
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/e9b51731911566bbf7e4895475a87fe06961de0b.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/e9b51731911566bbf7e4895475a87fe06961de0b.tar.gz"
+      }
+    },
     "nixpkgs_2": {
       "locked": {
         "lastModified": 1735554305,
@@ -108,12 +138,57 @@
         "flake-parts": "flake-parts",
         "nix-darwin": "nix-darwin",
         "nixpkgs": "nixpkgs",
+        "secrets": "secrets",
+        "treefmt-nix": "treefmt-nix_2"
+      }
+    },
+    "secrets": {
+      "inputs": {
+        "flake-parts": "flake-parts_2",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
         "treefmt-nix": "treefmt-nix"
+      },
+      "locked": {
+        "lastModified": 1737747806,
+        "narHash": "sha256-o1WPFyyyKbk2cpB3ZeOEE4O70hJc/M1CF4ca2yrLDCI=",
+        "ref": "main",
+        "rev": "c1801bb96ed2234fec1f1b67e4af721ee23dc9a7",
+        "shallow": true,
+        "type": "git",
+        "url": "ssh://git@github.com/johnjameswhitman/kipos-secrets.git"
+      },
+      "original": {
+        "ref": "main",
+        "shallow": true,
+        "type": "git",
+        "url": "ssh://git@github.com/johnjameswhitman/kipos-secrets.git"
       }
     },
     "treefmt-nix": {
       "inputs": {
         "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1737483750,
+        "narHash": "sha256-5An1wq5U8sNycOBBg3nsDDgpwBmR9liOpDGlhliA6Xo=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "f2cc121df15418d028a59c9737d38e3a90fbaf8f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "treefmt-nix_2": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
       },
       "locked": {
         "lastModified": 1736154270,

--- a/flake.nix
+++ b/flake.nix
@@ -83,7 +83,10 @@
         {
 
           checks."x86_64-linux" = {
-            hello = x86_64_linux_pkgs.testers.runNixOSTest ./tests/hello.nix;
+            hello = x86_64_linux_pkgs.testers.runNixOSTest {
+              imports = [ ./tests/hello.nix ];
+              defaults.etc."dummy".text = secrets.dummy_secret;
+            };
             k3s-multi-node = x86_64_linux_pkgs.testers.runNixOSTest ./tests/k3s-multi-node.nix;
           };
 

--- a/flake.nix
+++ b/flake.nix
@@ -57,10 +57,6 @@
 
           devShells = {
             default = pkgs.mkShell {
-              # DUMMY = builtins.readFile inputs.secrets + "/tests/dummy_keys.txt";
-              DUMMY = inputs.secrets.dummy.hello;
-              BUMMY = inputs.secrets.dummy.age_key;
-              MUMMY = inputs.secrets.dummy.sops_yaml;
               nativeBuildInputs = with pkgs; [
                 act
                 nixd
@@ -95,14 +91,15 @@
               ];
               # There has to be a better way to get this into the test machine.
               defaults.environment.etc = {
+                "hello" = inputs.secrets.dummy.hello;
                 "sops/age/keys.txt".text = inputs.secrets.dummy.age_key;
                 "sops/secrets.yaml".text = inputs.secrets.dummy.sops_yaml;
               };
-              defaults.sops = {
-                age.keyFile = "/etc/sops/age/keys.txt";
-                defaultSopsFile = "/etc/sops/secrets.yaml";
-                secrets.hello = { };
-              };
+              # defaults.sops = {
+              #   age.keyFile = "/etc/sops/age/keys.txt";
+              #   defaultSopsFile = "/etc/sops/secrets.yaml";
+              #   secrets.hello = { };
+              # };
             };
             k3s-multi-node = x86_64_linux_pkgs.testers.runNixOSTest ./tests/k3s-multi-node.nix;
           };

--- a/flake.nix
+++ b/flake.nix
@@ -84,23 +84,26 @@
 
           secrets_path = builtins.toString inputs.secrets;
           checks."x86_64-linux" = {
-            hello = x86_64_linux_pkgs.testers.runNixOSTest {
-              imports = [
-                # inputs.sops-nix.nixosModules.sops
-                ./tests/hello.nix
-              ];
-              # There has to be a better way to get this into the test machine.
-              defaults.environment.etc = {
-                "hello".text = inputs.secrets.dummy.hello;
-                "sops/age/keys.txt".text = inputs.secrets.dummy.age_key;
-                "sops/secrets.yaml".text = inputs.secrets.dummy.sops_yaml;
-              };
-              # defaults.sops = {
-              #   age.keyFile = "/etc/sops/age/keys.txt";
-              #   defaultSopsFile = "/etc/sops/secrets.yaml";
-              #   secrets.hello = { };
-              # };
-            };
+            # hello = x86_64_linux_pkgs.testers.runNixOSTest {
+            # imports = [
+            #   # inputs.sops-nix.nixosModules.sops
+            #   ./tests/hello.nix
+            # ];
+            # There has to be a better way to get this into the test machine.
+            # defaults.environment.etc = {
+            #   "hello".text = inputs.secrets.dummy.hello;
+            #   "sops/age/keys.txt".text = inputs.secrets.dummy.age_key;
+            #   "sops/secrets.yaml".text = inputs.secrets.dummy.sops_yaml;
+            # };
+            # defaults.sops = {
+            #   age.keyFile = "/etc/sops/age/keys.txt";
+            #   defaultSopsFile = "/etc/sops/secrets.yaml";
+            #   secrets.hello = { };
+            # };
+            # };
+            # https://discourse.nixos.org/t/infinite-recursion-when-modularizing-flake-runnixostest/58579/6
+            # Run with: nix run -L .\#checks.x86_64-linux.test.driverInteractive
+            hello = x86_64_linux_pkgs.testers.runNixOSTest (import ./tests/hello.nix { inherit inputs; });
             k3s-multi-node = x86_64_linux_pkgs.testers.runNixOSTest ./tests/k3s-multi-node.nix;
           };
 

--- a/flake.nix
+++ b/flake.nix
@@ -79,8 +79,8 @@
             system = "x86_64-linux";
             config.allowUnfree = true;
           };
-          # secrets_path = builtins.toString inputs.secrets;
         in
+        # secrets_path = builtins.toString inputs.secrets;
         {
 
           checks."x86_64-linux" = {

--- a/flake.nix
+++ b/flake.nix
@@ -91,7 +91,7 @@
               ];
               # There has to be a better way to get this into the test machine.
               defaults.environment.etc = {
-                "hello" = inputs.secrets.dummy.hello;
+                "hello".text = inputs.secrets.dummy.hello;
                 "sops/age/keys.txt".text = inputs.secrets.dummy.age_key;
                 "sops/secrets.yaml".text = inputs.secrets.dummy.sops_yaml;
               };

--- a/flake.nix
+++ b/flake.nix
@@ -87,7 +87,7 @@
             hello = x86_64_linux_pkgs.testers.runNixOSTest {
               imports = [
                 ./tests/hello.nix
-                inputs.sops-nix
+                inputs.sops-nix.nixosModules.sops
               ];
               # There has to be a better way to get this into the test machine.
               defaults.environment.etc = {

--- a/flake.nix
+++ b/flake.nix
@@ -84,23 +84,6 @@
 
           secrets_path = builtins.toString inputs.secrets;
           checks."x86_64-linux" = {
-            # hello = x86_64_linux_pkgs.testers.runNixOSTest {
-            # imports = [
-            #   # inputs.sops-nix.nixosModules.sops
-            #   ./tests/hello.nix
-            # ];
-            # There has to be a better way to get this into the test machine.
-            # defaults.environment.etc = {
-            #   "hello".text = inputs.secrets.dummy.hello;
-            #   "sops/age/keys.txt".text = inputs.secrets.dummy.age_key;
-            #   "sops/secrets.yaml".text = inputs.secrets.dummy.sops_yaml;
-            # };
-            # defaults.sops = {
-            #   age.keyFile = "/etc/sops/age/keys.txt";
-            #   defaultSopsFile = "/etc/sops/secrets.yaml";
-            #   secrets.hello = { };
-            # };
-            # };
             # https://discourse.nixos.org/t/infinite-recursion-when-modularizing-flake-runnixostest/58579/6
             # Run with: nix run -L .\#checks.x86_64-linux.test.driverInteractive
             hello = x86_64_linux_pkgs.testers.runNixOSTest (import ./tests/hello.nix { inherit inputs; });

--- a/flake.nix
+++ b/flake.nix
@@ -85,7 +85,7 @@
           checks."x86_64-linux" = {
             hello = x86_64_linux_pkgs.testers.runNixOSTest {
               imports = [ ./tests/hello.nix ];
-              defaults.etc."dummy".text = secrets.dummy_secret;
+              defaults.environment.etc."dummy".text = secrets.dummy_secret;
             };
             k3s-multi-node = x86_64_linux_pkgs.testers.runNixOSTest ./tests/k3s-multi-node.nix;
           };

--- a/flake.nix
+++ b/flake.nix
@@ -57,6 +57,10 @@
 
           devShells = {
             default = pkgs.mkShell {
+              # DUMMY = builtins.readFile inputs.secrets + "/tests/dummy_keys.txt";
+              DUMMY = inputs.secrets.dummy.hello;
+              BUMMY = inputs.secrets.dummy.age_key;
+              MUMMY = inputs.secrets.dummy.sops_yaml;
               nativeBuildInputs = with pkgs; [
                 act
                 nixd
@@ -80,9 +84,9 @@
             config.allowUnfree = true;
           };
         in
-        # secrets_path = builtins.toString inputs.secrets;
         {
 
+          secrets_path = builtins.toString inputs.secrets;
           checks."x86_64-linux" = {
             hello = x86_64_linux_pkgs.testers.runNixOSTest {
               imports = [
@@ -91,8 +95,8 @@
               ];
               # There has to be a better way to get this into the test machine.
               defaults.environment.etc = {
-                "sops/age/keys.txt".text = builtins.readFile inputs.secrets + "/tests/dummy_keys.txt";
-                "sops/secrets.yaml".text = builtins.readFile inputs.secrets + "/tests/secrets.yaml";
+                "sops/age/keys.txt".text = inputs.secrets.dummy.age_key;
+                "sops/secrets.yaml".text = inputs.secrets.dummy.sops_yaml;
               };
             };
             k3s-multi-node = x86_64_linux_pkgs.testers.runNixOSTest ./tests/k3s-multi-node.nix;

--- a/flake.nix
+++ b/flake.nix
@@ -6,9 +6,6 @@
 
     flake-parts.url = "github:hercules-ci/flake-parts";
 
-    # sops-nix.url = "github:Mic92/sops-nix";
-    # sops-nix.inputs.nixpkgs.follows = "nixpkgs";
-
     disko.url = "github:nix-community/disko";
     disko.inputs.nixpkgs.follows = "nixpkgs";
 
@@ -16,6 +13,14 @@
     nix-darwin.inputs.nixpkgs.follows = "nixpkgs";
 
     treefmt-nix.url = "github:numtide/treefmt-nix";
+    treefmt-nix.inputs.nixpkgs.follows = "nixpkgs";
+
+    # sops-nix.url = "github:Mic92/sops-nix";
+    # sops-nix.inputs.nixpkgs.follows = "nixpkgs";
+
+    secrets.url = "git+ssh://git@github.com/johnjameswhitman/kipos-secrets.git?ref=main&shallow=1";
+    secrets.inputs.nixpkgs.follows = "nixpkgs";
+
   };
 
   outputs =
@@ -26,6 +31,7 @@
       self,
       # sops-nix,
       nix-darwin,
+      secrets,
       ...
     }:
     flake-parts.lib.mkFlake { inherit inputs; } {

--- a/flake.nix
+++ b/flake.nix
@@ -90,13 +90,18 @@
           checks."x86_64-linux" = {
             hello = x86_64_linux_pkgs.testers.runNixOSTest {
               imports = [
-                ./tests/hello.nix
                 inputs.sops-nix.nixosModules.sops
+                ./tests/hello.nix
               ];
               # There has to be a better way to get this into the test machine.
               defaults.environment.etc = {
                 "sops/age/keys.txt".text = inputs.secrets.dummy.age_key;
                 "sops/secrets.yaml".text = inputs.secrets.dummy.sops_yaml;
+              };
+              defaults.sops = {
+                age.keyFile = "/etc/sops/age/keys.txt";
+                defaultSopsFile = "/etc/sops/secrets.yaml";
+                secrets.hello = { };
               };
             };
             k3s-multi-node = x86_64_linux_pkgs.testers.runNixOSTest ./tests/k3s-multi-node.nix;

--- a/flake.nix
+++ b/flake.nix
@@ -86,7 +86,7 @@
           checks."x86_64-linux" = {
             hello = x86_64_linux_pkgs.testers.runNixOSTest {
               imports = [
-                inputs.sops-nix.nixosModules.sops
+                # inputs.sops-nix.nixosModules.sops
                 ./tests/hello.nix
               ];
               # There has to be a better way to get this into the test machine.

--- a/tests/hello.nix
+++ b/tests/hello.nix
@@ -24,10 +24,10 @@
         sops = {
           # age.keyFile = "/etc/sops/age/keys.txt";
           # defaultSopsFile = "/etc/sops/secrets.yaml";
-          # age.keyFile = "${secrets_path}/tests/dummy_keys.txt";
-          # defaultSopsFile = "${secrets_path}/tests/secrets.yaml";
-          age.keyFile = builtins.toString (pkgs.writeText "keys.txt" inputs.secrets.dummy.age_key);
-          defaultSopsFile = pkgs.writeText "secrets.yaml" inputs.secrets.dummy.sops_yaml;
+          age.keyFile = "${secrets_path}/tests/dummy_keys.txt";
+          defaultSopsFile = /. + "${secrets_path}/tests/secrets.yaml";
+          # age.keyFile = builtins.toString (pkgs.writeText "keys.txt" inputs.secrets.dummy.age_key);
+          # defaultSopsFile = pkgs.writeText "secrets.yaml" inputs.secrets.dummy.sops_yaml;
           secrets.hello = { };
         };
       };

--- a/tests/hello.nix
+++ b/tests/hello.nix
@@ -35,7 +35,7 @@
   };
   testScript = ''
     start_all()
-    machine1.wait_for_unit("sops-nix.service")
+    # machine1.wait_for_unit("sops-nix.service")
     machine1.wait_for_unit("sshd.service")
     machine1.succeed("hello")
     machine1.succeed("[[ $(cat /etc/hello) == world ]]")

--- a/tests/hello.nix
+++ b/tests/hello.nix
@@ -10,7 +10,7 @@
         sops = {
           age.keyFile = "/etc/sops/age/keys.txt";
           defaultSopsFile = "/etc/sops/secrets.yaml";
-          secrets.hello = { };
+          secrets.hello.mode = "0444";
         };
       };
   };

--- a/tests/hello.nix
+++ b/tests/hello.nix
@@ -7,7 +7,7 @@
       {
         imports = [
           ../machines/hello.nix
-          inputs.sops.nixosModules.sops
+          inputs.sops-nix.nixosModules.sops
         ];
 
         environment.systemPackages = [ pkgs.hello ];

--- a/tests/hello.nix
+++ b/tests/hello.nix
@@ -4,6 +4,9 @@
   nodes = {
     machine1 =
       { pkgs, ... }:
+      let
+        secrets_path = builtins.toString inputs.secrets;
+      in
       {
         imports = [
           ../machines/hello.nix
@@ -19,8 +22,10 @@
         };
 
         sops = {
-          age.keyFile = "/etc/sops/age/keys.txt";
-          defaultSopsFile = "/etc/sops/secrets.yaml";
+          # age.keyFile = "/etc/sops/age/keys.txt";
+          # defaultSopsFile = "/etc/sops/secrets.yaml";
+          age.keyFile = "${secrets_path}/tests/dummy_keys.txt";
+          defaultSopsFile = "${secrets_path}/tests/secrets.yaml";
           secrets.hello = { };
         };
       };

--- a/tests/hello.nix
+++ b/tests/hello.nix
@@ -7,12 +7,17 @@
       {
         imports = [ ../machines/hello.nix ];
         environment.systemPackages = [ pkgs.hello ];
+        sops = {
+          age.keyFile = "/etc/sops/age/keys.txt";
+          defaultSopsFile = "/etc/sops/secrets.yaml";
+          secrets.hello = { };
+        };
       };
   };
   testScript = ''
     start_all()
-    machine1.wait_for_unit("sshd.service")
+    machine1.wait_for_unit("sops-nix.service")
     machine1.succeed("hello")
-    machine1.succeed("cat /etc/dummy")
+    machine1.succeed("[[ $(cat /run/secrets/hello) == world ]]")
   '';
 }

--- a/tests/hello.nix
+++ b/tests/hello.nix
@@ -22,10 +22,10 @@
         };
 
         sops = {
-          # age.keyFile = "/etc/sops/age/keys.txt";
-          # defaultSopsFile = "/etc/sops/secrets.yaml";
-          age.keyFile = "${secrets_path}/tests/dummy_keys.txt";
-          defaultSopsFile = inputs.secrets + "/tests/secrets.yaml";
+          age.keyFile = "/etc/sops/age/keys.txt";
+          defaultSopsFile = "/etc/sops/secrets.yaml";
+          # age.keyFile = "${secrets_path}/tests/dummy_keys.txt";
+          # defaultSopsFile = inputs.secrets + "/tests/secrets.yaml";
           # age.keyFile = builtins.toString (pkgs.writeText "keys.txt" inputs.secrets.dummy.age_key);
           # defaultSopsFile = pkgs.writeText "secrets.yaml" inputs.secrets.dummy.sops_yaml;
           secrets.hello = { };

--- a/tests/hello.nix
+++ b/tests/hello.nix
@@ -1,4 +1,4 @@
-{ pkgs, inputs, ... }:
+{ inputs, ... }:
 {
   name = "hello";
   nodes = {

--- a/tests/hello.nix
+++ b/tests/hello.nix
@@ -27,7 +27,7 @@
           # age.keyFile = "${secrets_path}/tests/dummy_keys.txt";
           # defaultSopsFile = "${secrets_path}/tests/secrets.yaml";
           age.keyFile = builtins.toString (pkgs.writeText "keys.txt" inputs.secrets.dummy.age_key);
-          defaultSopsFile = builtins.toString (pkgs.writeText "secrets.yaml" inputs.secrets.dummy.sops_yaml);
+          defaultSopsFile = pkgs.writeText "secrets.yaml" inputs.secrets.dummy.sops_yaml;
           secrets.hello = { };
         };
       };

--- a/tests/hello.nix
+++ b/tests/hello.nix
@@ -24,8 +24,10 @@
         sops = {
           # age.keyFile = "/etc/sops/age/keys.txt";
           # defaultSopsFile = "/etc/sops/secrets.yaml";
-          age.keyFile = "${secrets_path}/tests/dummy_keys.txt";
-          defaultSopsFile = "${secrets_path}/tests/secrets.yaml";
+          # age.keyFile = "${secrets_path}/tests/dummy_keys.txt";
+          # defaultSopsFile = "${secrets_path}/tests/secrets.yaml";
+          age.keyFile = pkgs.writeText "keys.txt" inputs.secrets.dummy.age_key;
+          defaultSopsFile = pkgs.writeText "secrets.yaml" inputs.secrets.dummy.sops_yaml;
           secrets.hello = { };
         };
       };

--- a/tests/hello.nix
+++ b/tests/hello.nix
@@ -24,11 +24,10 @@
         sops = {
           age.keyFile = "/etc/sops/age/keys.txt";
           defaultSopsFile = "/etc/sops/secrets.yaml";
+          # sops-nix complained about the secrets not living in the store, but
+          # I had trouble finding an approach that exposed secrets.yaml from
+          # the host store (CI kept complanining that the path did not exist).
           validateSopsFiles = false;
-          # age.keyFile = "${secrets_path}/tests/dummy_keys.txt";
-          # defaultSopsFile = inputs.secrets + "/tests/secrets.yaml";
-          # age.keyFile = builtins.toString (pkgs.writeText "keys.txt" inputs.secrets.dummy.age_key);
-          # defaultSopsFile = pkgs.writeText "secrets.yaml" inputs.secrets.dummy.sops_yaml;
           secrets.hello = { };
         };
       };

--- a/tests/hello.nix
+++ b/tests/hello.nix
@@ -11,7 +11,8 @@
   };
   testScript = ''
     start_all()
-    machine1.wait_for_unit("sops-nix.service")
+    # machine1.wait_for_unit("sops-nix.service")
+    machine1.wait_for_unit("sshd.service")
     machine1.succeed("hello")
     # machine1.succeed("[[ $(cat /run/secrets/hello) == world ]]")
     machine1.succeed("[[ $(cat /etc/hello) == world ]]")

--- a/tests/hello.nix
+++ b/tests/hello.nix
@@ -7,7 +7,6 @@
       {
         imports = [ ../machines/hello.nix ];
         environment.systemPackages = [ pkgs.hello ];
-        environment.etc."dummy".text = secrets.dummy_secret;
       };
   };
   testScript = ''

--- a/tests/hello.nix
+++ b/tests/hello.nix
@@ -9,7 +9,7 @@
         environment.systemPackages = [ pkgs.hello ];
         sops = {
           age.keyFile = "/etc/sops/age/keys.txt";
-          defaultSopsFile = "/etc/sops/secrets.yaml";
+          defaultSopsFile = /etc/sops/secrets.yaml;
           secrets.hello.mode = "0444";
         };
       };

--- a/tests/hello.nix
+++ b/tests/hello.nix
@@ -24,6 +24,7 @@
         sops = {
           age.keyFile = "/etc/sops/age/keys.txt";
           defaultSopsFile = "/etc/sops/secrets.yaml";
+          validateSopsFiles = false;
           # age.keyFile = "${secrets_path}/tests/dummy_keys.txt";
           # defaultSopsFile = inputs.secrets + "/tests/secrets.yaml";
           # age.keyFile = builtins.toString (pkgs.writeText "keys.txt" inputs.secrets.dummy.age_key);

--- a/tests/hello.nix
+++ b/tests/hello.nix
@@ -26,8 +26,8 @@
           # defaultSopsFile = "/etc/sops/secrets.yaml";
           # age.keyFile = "${secrets_path}/tests/dummy_keys.txt";
           # defaultSopsFile = "${secrets_path}/tests/secrets.yaml";
-          age.keyFile = pkgs.writeText "keys.txt" inputs.secrets.dummy.age_key;
-          defaultSopsFile = pkgs.writeText "secrets.yaml" inputs.secrets.dummy.sops_yaml;
+          age.keyFile = builtins.toString (pkgs.writeText "keys.txt" inputs.secrets.dummy.age_key);
+          defaultSopsFile = builtins.toString (pkgs.writeText "secrets.yaml" inputs.secrets.dummy.sops_yaml);
           secrets.hello = { };
         };
       };

--- a/tests/hello.nix
+++ b/tests/hello.nix
@@ -10,7 +10,7 @@
         sops = {
           age.keyFile = "/etc/sops/age/keys.txt";
           defaultSopsFile = /etc/sops/secrets.yaml;
-          secrets.hello.mode = "0444";
+          secrets.hello.neededForUsers = false;
         };
       };
   };

--- a/tests/hello.nix
+++ b/tests/hello.nix
@@ -1,4 +1,4 @@
-{ pkgs, ... }:
+{ pkgs, secrets, ... }:
 {
   name = "hello";
   nodes = {
@@ -7,11 +7,13 @@
       {
         imports = [ ../machines/hello.nix ];
         environment.systemPackages = [ pkgs.hello ];
+        environment.etc."dummy".text = secrets.dummy_secret;
       };
   };
   testScript = ''
     start_all()
     machine1.wait_for_unit("sshd.service")
     machine1.succeed("hello")
+    machine1.succeed("cat /etc/dummy")
   '';
 }

--- a/tests/hello.nix
+++ b/tests/hello.nix
@@ -1,4 +1,4 @@
-{ pkgs, secrets, ... }:
+{ pkgs, ... }:
 {
   name = "hello";
   nodes = {
@@ -7,17 +7,13 @@
       {
         imports = [ ../machines/hello.nix ];
         environment.systemPackages = [ pkgs.hello ];
-        sops = {
-          age.keyFile = "/etc/sops/age/keys.txt";
-          defaultSopsFile = /etc/sops/secrets.yaml;
-          secrets.hello.neededForUsers = false;
-        };
       };
   };
   testScript = ''
     start_all()
     machine1.wait_for_unit("sops-nix.service")
     machine1.succeed("hello")
-    machine1.succeed("[[ $(cat /run/secrets/hello) == world ]]")
+    # machine1.succeed("[[ $(cat /run/secrets/hello) == world ]]")
+    machine1.succeed("[[ $(cat /etc/hello) == world ]]")
   '';
 }

--- a/tests/hello.nix
+++ b/tests/hello.nix
@@ -1,20 +1,36 @@
-{ pkgs, ... }:
+{ pkgs, inputs, ... }:
 {
   name = "hello";
   nodes = {
     machine1 =
       { pkgs, ... }:
       {
-        imports = [ ../machines/hello.nix ];
+        imports = [
+          ../machines/hello.nix
+          inputs.sops.nixosModules.sops
+        ];
+
         environment.systemPackages = [ pkgs.hello ];
+
+        environment.etc = {
+          "hello".text = inputs.secrets.dummy.hello;
+          "sops/age/keys.txt".text = inputs.secrets.dummy.age_key;
+          "sops/secrets.yaml".text = inputs.secrets.dummy.sops_yaml;
+        };
+
+        sops = {
+          age.keyFile = "/etc/sops/age/keys.txt";
+          defaultSopsFile = "/etc/sops/secrets.yaml";
+          secrets.hello = { };
+        };
       };
   };
   testScript = ''
     start_all()
-    # machine1.wait_for_unit("sops-nix.service")
+    machine1.wait_for_unit("sops-nix.service")
     machine1.wait_for_unit("sshd.service")
     machine1.succeed("hello")
-    # machine1.succeed("[[ $(cat /run/secrets/hello) == world ]]")
     machine1.succeed("[[ $(cat /etc/hello) == world ]]")
+    machine1.succeed("[[ $(cat /run/secrets/hello) == world ]]")
   '';
 }

--- a/tests/hello.nix
+++ b/tests/hello.nix
@@ -25,7 +25,7 @@
           # age.keyFile = "/etc/sops/age/keys.txt";
           # defaultSopsFile = "/etc/sops/secrets.yaml";
           age.keyFile = "${secrets_path}/tests/dummy_keys.txt";
-          defaultSopsFile = /. + "${secrets_path}/tests/secrets.yaml";
+          defaultSopsFile = inputs.secrets + "/tests/secrets.yaml";
           # age.keyFile = builtins.toString (pkgs.writeText "keys.txt" inputs.secrets.dummy.age_key);
           # defaultSopsFile = pkgs.writeText "secrets.yaml" inputs.secrets.dummy.sops_yaml;
           secrets.hello = { };


### PR DESCRIPTION
# Problem

I need to be able to reference various API keys, etc without exposing them in my configs.

# Solution

Wire sops secrets in from a private repo. This is based on the pattern from [EmergentMind/nix-secrets-reference](https://github.com/EmergentMind/nix-secrets-reference).

- [x] Set up `kipos-secrets` non-public repo to hold SOPS yaml (ref [sops-nix][sops_nix]
   for basic getting-started info)
- [x] Generate `kipos-secrets` [Deploy Key][gh_deploy_keys] pair (public key
   goes into `kipos-secrets` settings, private key goes into `kipos`
   secret)
- [x] Update `kipos` GHA to load private Deploy Key from secret into
   ssh-agent
- [x] Reference `kipos-secrets` as an input to flake
- [x] Wire dummy secrets into `hello.nix` test